### PR TITLE
Exposing variables for Bitrise CI

### DIFF
--- a/Helpers/VersionWizard.sh
+++ b/Helpers/VersionWizard.sh
@@ -124,6 +124,11 @@ curl "https://uad.io/versionWizard.php?id=${VW_APP_ID}&commit=${COMMIT}" -o $JSO
 PUBLIC="$(jq -r '.publicVersion' $JSON)"
 BUILD="$(jq -r '.buildNumber' $JSON)"
 rm $JSON
+# Export variables to be used in Bitrise CI thought envman
+which envman 2>/dev/null && {
+    envman add --key APP_VERSION --value "${PUBLIC}"
+    envman add --key APP_BUILD --value "${BUILD}"
+}
 
 # Change public version format based on flags
 if [ "${VW_PUBLIC_VERSION_MODE}" = "semver_nozero" ]; then

--- a/Helpers/VersionWizard2.sh
+++ b/Helpers/VersionWizard2.sh
@@ -260,6 +260,11 @@ JSON=`mktemp`.json || fail "Unable to create temporary file"
 PUBLIC="$(jq -r '.public' $JSON)"
 BUILD="$(jq -r '.build' $JSON)"
 rm $JSON
+# Export variables to be used in Bitrise CI thought envman
+which envman 2>/dev/null && {
+    envman add --key APP_VERSION --value "${PUBLIC}"
+    envman add --key APP_BUILD --value "${BUILD}"
+}
 
 # Change build number into public.build if needed
 [ -z ${VW_PREPEND_PUBLIC_TO_BUILD+x} ] || BUILD="$PUBLIC.$BUILD"


### PR DESCRIPTION
# Change: Export variables to be used in Bitrise CI through envman

# Description:
This pull request adds a script to export variables for usage in Bitrise CI through envman. It adds the variables `APP_VERSION` and `APP_BUILD` with their respective values `${PUBLIC}` and `${BUILD}`.

# Reason for the change:
By exporting these variables, we enable the Bitrise CI environment to access the values of `APP_VERSION` and `APP_BUILD`, providing flexibility and consistency in our CI/CD processes.

# Proposed modifications:

Added a script to export `APP_VERSION` with the value `${PUBLIC}` using envman.
Added a script to export `APP_BUILD` with the value `${BUILD}` using envman.

Please review these changes and let me know if any further modifications are required.